### PR TITLE
Add VERP encoding policy

### DIFF
--- a/slimta/lookup/drivers/__init__.py
+++ b/slimta/lookup/drivers/__init__.py
@@ -41,6 +41,15 @@ class LookupBase(object):
 
     """
 
+    def _format_key(self, key_template, kwargs):
+        kwargs = kwargs.copy()
+        while True:
+            try:
+                return key_template.format(**kwargs)
+            except KeyError as exc:
+                key = exc.args[0]
+                kwargs[key] = '{'+key+'}'
+
     def lookup(self, **kwargs):
         """The keyword arguments will be used by the lookup driver to return a
         dictionary-like object that will be used to affect actions or policy.

--- a/slimta/lookup/drivers/dict.py
+++ b/slimta/lookup/drivers/dict.py
@@ -54,12 +54,11 @@ class DictLookup(LookupBase):
         self.key_template = key_template
 
     def lookup(self, **kwargs):
-        ret = None
+        key = self._format_key(self.key_template, kwargs)
         try:
-            key = self.key_template.format(**kwargs)
             ret = self.backend[key]
         except KeyError:
-            pass
+            ret = None
         self.log(__name__, kwargs, ret)
         return ret
 

--- a/slimta/lookup/drivers/redis.py
+++ b/slimta/lookup/drivers/redis.py
@@ -97,10 +97,7 @@ class RedisLookup(LookupBase):
         return self.redis.hgetall(key)
 
     def lookup(self, **kwargs):
-        try:
-            key = self.key_template.format(**kwargs)
-        except KeyError:
-            return
+        key = self._format_key(self.key_template, kwargs)
         ret = self._key_lookup(key)
         self.log(__name__, kwargs, ret)
         return ret

--- a/test/test_slimta_lookup_policy.py
+++ b/test/test_slimta_lookup_policy.py
@@ -1,0 +1,42 @@
+
+from mox3.mox import MoxTestBase, IsA
+
+from slimta.envelope import Envelope
+from slimta.lookup.policy import LookupPolicy
+from slimta.lookup.drivers.dict import DictLookup
+
+
+class TestDictLookup(MoxTestBase):
+
+    def setUp(self):
+        super(TestDictLookup, self).setUp()
+        self.data = {}
+        self.drv = DictLookup(self.data, '{address}')
+        self.policy = LookupPolicy(self.drv, True, True)
+
+    def test_verp(self):
+        self.data['sender@example.com'] = {'verp': 'verp.com'}
+        self.data['rcpt2@example.com'] = {'verp': 'verp.com'}
+        env = Envelope('sender@example.com', ['rcpt1@example.com', 'rcpt2@example.com'])
+        self.policy.apply(env)
+        self.assertEquals('sender=example.com@verp.com', env.sender)
+        self.assertEquals(['rcpt1@example.com', 'rcpt2=example.com@verp.com'], env.recipients)
+
+    def test_alias(self):
+        self.data['sender@example.com'] = {'alias': 'sender@other.com'}
+        self.data['rcpt2@example.com'] = {'alias': 'other.com'}
+        env = Envelope('sender@example.com', ['rcpt1@example.com', 'rcpt2@example.com'])
+        self.policy.apply(env)
+        self.assertEquals('sender@other.com', env.sender)
+        self.assertEquals(['rcpt1@example.com', 'rcpt2@other.com'], env.recipients)
+
+    def test_add_headers(self):
+        self.data['sender@example.com'] = {'add_headers': '{"X-Test-A": "one"}'}
+        self.data['rcpt2@example.com'] = {'add_headers': '{"X-Test-B": "two"}'}
+        env = Envelope('sender@example.com', ['rcpt1@example.com', 'rcpt2@example.com'])
+        env.parse(b"""\n\n""")
+        self.policy.apply(env)
+        self.assertEquals('one', env.headers['x-test-a'])
+        self.assertEquals('two', env.headers['x-test-b'])
+
+# vim:et:fdm=marker:sts=4:sw=4:ts=4:tw=0


### PR DESCRIPTION
Adds a lookup policy for aliasing `user@domain` to `user=domain@other-domain`, aka VERP encoding.